### PR TITLE
Provide commands to run via actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 pipeline:
   test:
-    image: golang:1.8
+    image: golang:1.9
     environment:
       - CGO_ENABLED=0
     commands:

--- a/main.go
+++ b/main.go
@@ -23,30 +23,30 @@ func main() {
 		// plugin args
 		//
 
-		cli.StringFlag{
-			Name:   "init_options",
-			Usage:  "options for the init command. See https://www.terraform.io/docs/commands/init.html",
-			EnvVar: "PLUGIN_INIT_OPTIONS",
-		},
-		cli.StringFlag{
-			Name:   "vars",
-			Usage:  "a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<value>` option",
-			EnvVar: "PLUGIN_VARS",
-		},
-		cli.StringFlag{
-			Name:   "secrets",
-			Usage:  "a map of secrets to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<ENV>` option",
-			EnvVar: "PLUGIN_SECRETS",
+		cli.StringSliceFlag{
+			Name:   "actions",
+			Usage:  "a list of actions to have terraform perform",
+			EnvVar: "PLUGIN_ACTIONS",
+			Value:  &cli.StringSlice{"validate", "apply"},
 		},
 		cli.StringFlag{
 			Name:   "ca_cert",
 			Usage:  "ca cert to add to your environment to allow terraform to use internal/private resources",
 			EnvVar: "PLUGIN_CA_CERT",
 		},
-		cli.BoolFlag{
-			Name:   "sensitive",
-			Usage:  "whether or not to suppress terraform commands to stdout",
-			EnvVar: "PLUGIN_SENSITIVE",
+		cli.StringFlag{
+			Name:  "env-file",
+			Usage: "source env file",
+		},
+		cli.StringFlag{
+			Name:   "init_options",
+			Usage:  "options for the init command. See https://www.terraform.io/docs/commands/init.html",
+			EnvVar: "PLUGIN_INIT_OPTIONS",
+		},
+		cli.IntFlag{
+			Name:   "parallelism",
+			Usage:  "The number of concurrent operations as Terraform walks its graph",
+			EnvVar: "PLUGIN_PARALLELISM",
 		},
 		cli.StringFlag{
 			Name:   "role_arn_to_assume",
@@ -58,38 +58,35 @@ func main() {
 			Usage:  "The root directory where the terraform files live. When unset, the top level directory will be assumed",
 			EnvVar: "PLUGIN_ROOT_DIR",
 		},
-		cli.IntFlag{
-			Name:   "parallelism",
-			Usage:  "The number of concurrent operations as Terraform walks its graph",
-			EnvVar: "PLUGIN_PARALLELISM",
-		},
-
 		cli.StringFlag{
-			Name:  "env-file",
-			Usage: "source env file",
+			Name:   "secrets",
+			Usage:  "a map of secrets to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<ENV>` option",
+			EnvVar: "PLUGIN_SECRETS",
 		},
-
+		cli.BoolFlag{
+			Name:   "sensitive",
+			Usage:  "whether or not to suppress terraform commands to stdout",
+			EnvVar: "PLUGIN_SENSITIVE",
+		},
 		cli.StringSliceFlag{
 			Name:   "targets",
 			Usage:  "targets to run apply or plan on",
 			EnvVar: "PLUGIN_TARGETS",
-		},
-
-		cli.StringSliceFlag{
-			Name:   "var_files",
-			Usage:  "a list of var files to use. Each value is passed as -var-file=<value>",
-			EnvVar: "PLUGIN_VAR_FILES",
 		},
 		cli.StringFlag{
 			Name:   "tf.version",
 			Usage:  "terraform version to use",
 			EnvVar: "PLUGIN_TF_VERSION",
 		},
+		cli.StringFlag{
+			Name:   "vars",
+			Usage:  "a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `<key>=<value>` option",
+			EnvVar: "PLUGIN_VARS",
+		},
 		cli.StringSliceFlag{
-			Name:   "actions",
-			Usage:  "a list of actions to have terraform perform",
-			EnvVar: "PLUGIN_ACTIONS",
-			Value:  &cli.StringSlice{"validate", "apply"},
+			Name:   "var_files",
+			Usage:  "a list of var files to use. Each value is passed as -var-file=<value>",
+			EnvVar: "PLUGIN_VAR_FILES",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -23,11 +23,6 @@ func main() {
 		// plugin args
 		//
 
-		cli.BoolFlag{
-			Name:   "plan",
-			Usage:  "calculates a plan but does NOT apply it",
-			EnvVar: "PLUGIN_PLAN",
-		},
 		cli.StringFlag{
 			Name:   "init_options",
 			Usage:  "options for the init command. See https://www.terraform.io/docs/commands/init.html",
@@ -85,15 +80,16 @@ func main() {
 			Usage:  "a list of var files to use. Each value is passed as -var-file=<value>",
 			EnvVar: "PLUGIN_VAR_FILES",
 		},
-		cli.BoolFlag{
-			Name:   "destroy",
-			Usage:  "destory all resurces",
-			EnvVar: "PLUGIN_DESTROY",
-		},
 		cli.StringFlag{
 			Name:   "tf.version",
 			Usage:  "terraform version to use",
 			EnvVar: "PLUGIN_TF_VERSION",
+		},
+		cli.StringSliceFlag{
+			Name:   "actions",
+			Usage:  "a list of actions to have terraform perform",
+			EnvVar: "PLUGIN_ACTIONS",
+			Value:  &cli.StringSlice{"validate", "apply"},
 		},
 	}
 
@@ -129,7 +125,7 @@ func run(c *cli.Context) error {
 
 	plugin := Plugin{
 		Config: Config{
-			Plan:        c.Bool("plan"),
+			Actions:    c.StringSlice("actions"),
 			Vars:        vars,
 			Secrets:     secrets,
 			InitOptions: initOptions,
@@ -140,7 +136,6 @@ func run(c *cli.Context) error {
 			Parallelism: c.Int("parallelism"),
 			Targets:     c.StringSlice("targets"),
 			VarFiles:    c.StringSlice("var_files"),
-			Destroy:     c.Bool("destroy"),
 		},
 		Terraform: Terraform{
 			Version: c.String("tf.version"),

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 			Name:   "actions",
 			Usage:  "a list of actions to have terraform perform",
 			EnvVar: "PLUGIN_ACTIONS",
-			Value:  &cli.StringSlice{"validate", "apply"},
+			Value:  &cli.StringSlice{"validate", "plan", "apply"},
 		},
 		cli.StringFlag{
 			Name:   "ca_cert",

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func run(c *cli.Context) error {
 
 	plugin := Plugin{
 		Config: Config{
-			Actions:    c.StringSlice("actions"),
+			Actions:     c.StringSlice("actions"),
 			Vars:        vars,
 			Secrets:     secrets,
 			InitOptions: initOptions,

--- a/plugin.go
+++ b/plugin.go
@@ -91,7 +91,7 @@ func (p Plugin) Exec() error {
 			commands = append(commands, tfPlan(p.Config, true))
 			commands = append(commands, tfDestroy(p.Config))
 		default:
-			return fmt.Errorf("valid actions are: validate, plan, apply, destroy.  You provided %s", action)
+			return fmt.Errorf("valid actions are: validate, plan, apply, plan-destroy, destroy.  You provided %s", action)
 		}
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -132,6 +132,7 @@ func installCaCert(cacert string) *exec.Cmd {
 	)
 }
 
+// CopyTfEnv creates copies of TF_VAR_ to lowercase
 func CopyTfEnv() {
 	tfVar := regexp.MustCompile(`^TF_VAR_.*$`)
 	for _, e := range os.Environ() {

--- a/plugin.go
+++ b/plugin.go
@@ -85,10 +85,8 @@ func (p Plugin) Exec() error {
 		case "plan-destroy":
 			commands = append(commands, tfPlan(p.Config, true))
 		case "apply":
-			commands = append(commands, tfPlan(p.Config, false))
 			commands = append(commands, tfApply(p.Config))
 		case "destroy":
-			commands = append(commands, tfPlan(p.Config, true))
 			commands = append(commands, tfDestroy(p.Config))
 		default:
 			return fmt.Errorf("valid actions are: validate, plan, apply, plan-destroy, destroy.  You provided %s", action)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -36,7 +36,7 @@ func Test_destroyCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := destroyCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+			if got := tfDestroy(tt.args.config); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("destroyCommand() = %v, want %v", got, tt.want)
 			}
 		})
@@ -70,37 +70,8 @@ func Test_applyCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := applyCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+			if got := tfApply(tt.args.config); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("applyCommand() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_terraformCommand(t *testing.T) {
-	type args struct {
-		config Config
-	}
-	tests := []struct {
-		name string
-		args args
-		want *exec.Cmd
-	}{
-		{
-			"default",
-			args{config: Config{}},
-			exec.Command("terraform", "apply", "plan.tfout"),
-		},
-		{
-			"destroy",
-			args{config: Config{Destroy: true}},
-			exec.Command("terraform", "destroy", "-force"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := terraformCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("terraformCommand() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -113,22 +84,25 @@ func Test_planCommand(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
+		destroy bool
 		want *exec.Cmd
 	}{
 		{
 			"default",
 			args{config: Config{}},
+			false,
 			exec.Command("terraform", "plan", "-out=plan.tfout"),
 		},
 		{
 			"destroy",
-			args{config: Config{Destroy: true}},
+			args{config: Config{}},
+			true,
 			exec.Command("terraform", "plan", "-destroy"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := planCommand(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+			if got := tfPlan(tt.args.config, tt.destroy); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("planCommand() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Valid actions would include: `validate`, `plan`, `apply`, `plan-destroy`, `destroy`

The following would still have `validate`, `plan`, `apply` by default.

```yaml
pipeline:
  terraform:
    image: jmccann/drone-terraform:latest
```

The following would "dry run" and `validate` and `plan` only:

```pipeline:
  terraform:
    image: jmccann/drone-terraform:latest
    actions:
      - validate
      - plan
```

The following would `validate` only:

```
pipeline:
  terraform:
    image: jmccann/drone-terraform:latest
    actions:
      - validate
```

The order the actions are listed in is the order they are executed.